### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   dry-run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jsade/atlassian-docs-to-markdown/security/code-scanning/1](https://github.com/jsade/atlassian-docs-to-markdown/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function. Based on the workflow's steps, it appears that the `contents: read` permission is sufficient, as the workflow does not perform any write operations. 

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `dry-run` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
